### PR TITLE
Removed the need to install lxml.

### DIFF
--- a/adaptor/fields.py
+++ b/adaptor/fields.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from lxml import etree
 
 from django.db.models import Model as djangoModel
 from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
@@ -177,6 +176,7 @@ class XMLField(Field):
                 return base_class
 
     def get_prep_value(self, value, instance=None):
+        from lxml import etree
         element = self.root if self.root is not None else etree.fromstring(value)
         values = element.xpath(self.path)
         if not values and self.null:
@@ -207,6 +207,7 @@ class XMLRootField(XMLField):
         pass
 
     def get_root(self, value):
+        from lxml import etree
         element = self.root if self.root is not None else etree.fromstring(value)
         return element.xpath(self.path)
 

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 import os
 from setuptools import setup
 
+
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
@@ -15,12 +16,13 @@ setup(name='django-adaptors',
       keywords="CSV XML Django adaptor",
       packages=['adaptor'],
       install_requires=[
-          'lxml>=2.3.4',
           'Django>=1.4',
       ],
+      extras_require={
+          'XML': ['lxml>=2.3.4']
+      },
       classifiers=[
-        "Development Status :: 3 - Alpha",
-        "Topic :: Utilities",
-        "License :: OSI Approved :: BSD License",
-    ],
-)
+          "Development Status :: 3 - Alpha",
+          "Topic :: Utilities",
+          "License :: OSI Approved :: BSD License",
+      ])


### PR DESCRIPTION
Hi,

Thanks for your time on this project!

As per the commit message:

> This package can be used as a CSV importer without the requirement of lxml and therefore I believe lxml should be an optional extra for when working explicitly with XML:
> - Removed from requirements.txt
> - Moved module level lxml imports to the method level; ideally the XML fields should be seperated off into another module so that this is not required.
> - Moved lxml requirement in setup.py from install_requires to extras_require.

Thanks,
Darian
