### PR TITLE
Bugfix: has_header doesn't work for headers that could validate as fields

### DIFF
--- a/adaptor/model.py
+++ b/adaptor/model.py
@@ -496,7 +496,7 @@ class CsvImporter(object):
             self.delimiter = self.csvModel.Meta.delimiter
 
     def import_from_filename(self, filename):
-        csv_file = open(filename)
+        csv_file = open(filename, 'rU')
         return self.import_from_file(csv_file)
 
     def import_from_file(self, csv_file):

--- a/adaptor/model.py
+++ b/adaptor/model.py
@@ -461,9 +461,15 @@ class CsvImporter(object):
 
     def import_data(self, data):
         lines = []
-        self.get_class_delimiter()
         line_number = 0
-        for line in csv.reader(data, delimiter=self.delimiter):
+        self.get_class_delimiter()
+        reader = csv.reader(data, delimiter=self.delimiter)
+
+        if self.csvModel.has_header():
+            reader.next()
+            line_number = 1
+
+        for line in reader:
             self.process_line(data, line, lines, line_number, self.csvModel)
             line_number += 1
         return lines
@@ -479,10 +485,7 @@ class CsvImporter(object):
         except ForeignKeyFieldError, e:
             raise CsvFieldDataException(line_number, field_error=e.message, model=e.model, value=e.value)
         except ValueError, e:
-            if line_number == 0 and self.csvModel.has_header():
-                pass
-            else:
-                raise CsvDataException(line_number, field_error=e.message)
+            raise CsvDataException(line_number, field_error=e.message)
         except IndexError, e:
             raise CsvDataException(line_number, error="Number of fields invalid")
         return value

--- a/tests/csv_tests.py
+++ b/tests/csv_tests.py
@@ -214,6 +214,25 @@ class TestCsvImporter(TestCase):
         test = TestCsvWithHeader.import_data(TestCsvWithHeader.test_data)
         self.assertEquals(MyModel.objects.all().count(), 2)
 
+    def test_with_valid_header(self):
+        class TestCsvWithValidHeader(CsvModel):
+            name = CharField()
+            category = CharField()
+            description = CharField()
+
+            class Meta:
+                delimiter = ";"
+                has_header = True
+
+            test_data = [
+                "Name;Category;Description", 
+                "Bread;Food;Traditional bread",
+                "Lettuce;Vegetable;Good for salad"
+            ]
+
+        test = TestCsvWithValidHeader.import_data(TestCsvWithValidHeader.test_data)
+        self.assertEquals(len(test), 2)
+
     def test_direct_to_db(self):
         test = TestCsvDBOnlyModel.import_data(TestCsvDBOnlyModel.test_data)
         self.assertEquals(MyModel.objects.all().count(), 2)


### PR DESCRIPTION
It seems like the "has_header" attribute was only checked if the current line couldn't be parsed.
I moved the check one level up, directly skipping the line on the csv reader.
