### PR TITLE
fields: allow None as a default value so that fields can be nulled

### DIFF
--- a/adaptor/fields.py
+++ b/adaptor/fields.py
@@ -57,21 +57,21 @@ class Field(BaseField):
     def get_prep_value(self, value, instance=None):
         try:
             value = self.prepare(value)
-            if not value and self.null and self.default is not None:
+            if not value and self.null:
                 value = self.default
             else:
                 value = self.to_python(value)
             if value not in self.choices:
                 if not self.null:
                     raise exceptions.ChoiceError("Value \'%s\' does not belong to %s" % (value, self.choices))
-                value = None 
+                value = None
             transform = self.get_transform_method(instance)
             value = transform(value)
             if not self.validator().validate(value):
                 raise exceptions.FieldError(self.validator.validation_message)
             return value
         except exceptions.ChoiceError:
-            raise 
+            raise
         except exceptions.FieldError:
             raise
         except ValueError:


### PR DESCRIPTION
this makes the following import model definition work "as expected" (writing null value if csv import value is empty string):

```
class import_Retailer( CsvModel ):
	VALID_TO = DateField( null=True, default=None )
```

(note: I'm sorry, my editor removed those spaces at the line endings on those 2 other lines)

this fixes #18 and maybe also #16